### PR TITLE
Bump json5, html-webpack-plugin and loader-utils

### DIFF
--- a/demos/router-playground-lazy-load-angular6/package-lock.json
+++ b/demos/router-playground-lazy-load-angular6/package-lock.json
@@ -289,6 +289,49 @@
 				"tslib": "^1.9.0"
 			}
 		},
+		"@jridgewell/gen-mapping": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"requires": {
+				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			}
+		},
+		"@jridgewell/resolve-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+		},
+		"@jridgewell/set-array": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+		},
+		"@jridgewell/source-map": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+			"requires": {
+				"@jridgewell/gen-mapping": "^0.3.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			}
+		},
+		"@jridgewell/sourcemap-codec": {
+			"version": "1.4.14",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+		},
+		"@jridgewell/trace-mapping": {
+			"version": "0.3.17",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+			"requires": {
+				"@jridgewell/resolve-uri": "3.1.0",
+				"@jridgewell/sourcemap-codec": "1.4.14"
+			}
+		},
 		"@ngtools/webpack": {
 			"version": "6.2.4",
 			"resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-6.2.4.tgz",
@@ -342,6 +385,11 @@
 					}
 				}
 			}
+		},
+		"@types/html-minifier-terser": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
+			"integrity": "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg=="
 		},
 		"@types/lodash": {
 			"version": "4.14.116",
@@ -532,7 +580,7 @@
 		},
 		"ajv": {
 			"version": "6.4.0",
-			"resolved": "http://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
 			"integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
 			"requires": {
 				"fast-deep-equal": "^1.0.0",
@@ -761,11 +809,6 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
-		"big.js": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
-		},
 		"binary-extensions": {
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
@@ -784,7 +827,7 @@
 		"boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -964,12 +1007,19 @@
 			}
 		},
 		"camel-case": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-			"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+			"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
 			"requires": {
-				"no-case": "^2.2.0",
-				"upper-case": "^1.1.1"
+				"pascal-case": "^3.1.2",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+					"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+				}
 			}
 		},
 		"camelcase": {
@@ -1056,9 +1106,9 @@
 			}
 		},
 		"clean-css": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
-			"integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.1.tgz",
+			"integrity": "sha512-lCr8OHhiWCTw4v8POJovCoh4T7I9U11yVsPjMWWnnMmp9ZowCxyad1Pathle/9HjaDp+fdQKjO9fQydE6RHTZg==",
 			"requires": {
 				"source-map": "~0.6.0"
 			},
@@ -1163,9 +1213,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.17.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -1204,7 +1254,8 @@
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+			"optional": true
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -1304,20 +1355,21 @@
 			}
 		},
 		"css-select": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+			"integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
 			"requires": {
-				"boolbase": "~1.0.0",
-				"css-what": "2.1",
-				"domutils": "1.5.1",
-				"nth-check": "~1.0.1"
+				"boolbase": "^1.0.0",
+				"css-what": "^6.0.1",
+				"domhandler": "^4.3.1",
+				"domutils": "^2.8.0",
+				"nth-check": "^2.0.1"
 			}
 		},
 		"css-what": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-			"integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
 		},
 		"cyclist": {
 			"version": "0.2.2",
@@ -1357,14 +1409,6 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-		},
-		"define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"requires": {
-				"object-keys": "^1.0.12"
-			}
 		},
 		"define-property": {
 			"version": "2.0.2",
@@ -1439,34 +1483,21 @@
 			}
 		},
 		"dom-converter": {
-			"version": "0.1.4",
-			"resolved": "http://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
-			"integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
+			"version": "0.2.0",
+			"resolved": "http://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
+			"integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
 			"requires": {
-				"utila": "~0.3"
-			},
-			"dependencies": {
-				"utila": {
-					"version": "0.3.3",
-					"resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
-					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY="
-				}
+				"utila": "~0.4"
 			}
 		},
 		"dom-serializer": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+			"integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
 			"requires": {
-				"domelementtype": "~1.1.1",
-				"entities": "~1.1.1"
-			},
-			"dependencies": {
-				"domelementtype": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
-				}
+				"domelementtype": "^2.0.1",
+				"domhandler": "^4.2.0",
+				"entities": "^2.0.0"
 			}
 		},
 		"domain-browser": {
@@ -1475,25 +1506,42 @@
 			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
 		},
 		"domelementtype": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
 		},
 		"domhandler": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
-			"integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+			"integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
 			"requires": {
-				"domelementtype": "1"
+				"domelementtype": "^2.2.0"
 			}
 		},
 		"domutils": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+			"integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
 			"requires": {
-				"dom-serializer": "0",
-				"domelementtype": "1"
+				"dom-serializer": "^1.0.1",
+				"domelementtype": "^2.2.0",
+				"domhandler": "^4.2.0"
+			}
+		},
+		"dot-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+			"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+			"requires": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+					"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+				}
 			}
 		},
 		"duplexify": {
@@ -1531,11 +1579,6 @@
 				"minimalistic-crypto-utils": "^1.0.0"
 			}
 		},
-		"emojis-list": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
-		},
 		"end-of-stream": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -1555,9 +1598,9 @@
 			}
 		},
 		"entities": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-			"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
 		},
 		"errno": {
 			"version": "0.1.7",
@@ -1565,28 +1608,6 @@
 			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 			"requires": {
 				"prr": "~1.0.1"
-			}
-		},
-		"es-abstract": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
-			"requires": {
-				"es-to-primitive": "^1.1.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.1",
-				"is-callable": "^1.1.3",
-				"is-regex": "^1.0.4"
-			}
-		},
-		"es-to-primitive": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-			"requires": {
-				"is-callable": "^1.1.1",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.1"
 			}
 		},
 		"escape-string-regexp": {
@@ -1951,7 +1972,8 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1969,11 +1991,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1986,15 +2010,18 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -2097,7 +2124,8 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -2107,6 +2135,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -2119,17 +2148,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -2146,6 +2178,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2218,7 +2251,8 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -2228,6 +2262,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -2303,7 +2338,8 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -2333,6 +2369,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -2350,6 +2387,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2388,18 +2426,15 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				}
 			}
-		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"gauge": {
 			"version": "2.7.4",
@@ -2546,14 +2581,6 @@
 				}
 			}
 		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
-		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -2613,9 +2640,9 @@
 			}
 		},
 		"he": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
@@ -2632,74 +2659,53 @@
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
 			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
 		},
-		"html-minifier": {
-			"version": "3.5.20",
-			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.20.tgz",
-			"integrity": "sha512-ZmgNLaTp54+HFKkONyLFEfs5dd/ZOtlquKaTnqIWFmx3Av5zG6ZPcV2d0o9XM2fXOTxxIf6eDcwzFFotke/5zA==",
+		"html-minifier-terser": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
+			"integrity": "sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==",
 			"requires": {
-				"camel-case": "3.0.x",
-				"clean-css": "4.2.x",
-				"commander": "2.17.x",
-				"he": "1.1.x",
-				"param-case": "2.1.x",
-				"relateurl": "0.2.x",
-				"uglify-js": "3.4.x"
+				"camel-case": "^4.1.2",
+				"clean-css": "^5.2.2",
+				"commander": "^8.3.0",
+				"he": "^1.2.0",
+				"param-case": "^3.0.4",
+				"relateurl": "^0.2.7",
+				"terser": "^5.10.0"
 			}
 		},
 		"html-webpack-plugin": {
-			"version": "3.2.0",
-			"resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
-			"integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
+			"version": "5.5.0",
+			"resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz",
+			"integrity": "sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==",
 			"requires": {
-				"html-minifier": "^3.2.3",
-				"loader-utils": "^0.2.16",
-				"lodash": "^4.17.3",
-				"pretty-error": "^2.0.2",
-				"tapable": "^1.0.0",
-				"toposort": "^1.0.0",
-				"util.promisify": "1.0.0"
+				"@types/html-minifier-terser": "^6.0.0",
+				"html-minifier-terser": "^6.0.2",
+				"lodash": "^4.17.21",
+				"pretty-error": "^4.0.0",
+				"tapable": "^2.0.0"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.21",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+				},
+				"tapable": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+					"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
+				}
 			}
 		},
 		"htmlparser2": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
-			"integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+			"integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
 			"requires": {
-				"domelementtype": "1",
-				"domhandler": "2.1",
-				"domutils": "1.1",
-				"readable-stream": "1.0"
-			},
-			"dependencies": {
-				"domutils": {
-					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
-					"integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
-					"requires": {
-						"domelementtype": "1"
-					}
-				},
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-				}
+				"domelementtype": "^2.0.1",
+				"domhandler": "^4.0.0",
+				"domutils": "^2.5.2",
+				"entities": "^2.0.0"
 			}
 		},
 		"http-signature": {
@@ -2863,11 +2869,6 @@
 				"builtin-modules": "^1.0.0"
 			}
 		},
-		"is-callable": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
-		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -2885,11 +2886,6 @@
 					}
 				}
 			}
-		},
-		"is-date-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
@@ -2983,23 +2979,10 @@
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
 			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
 		},
-		"is-regex": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-			"requires": {
-				"has": "^1.0.1"
-			}
-		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-		},
-		"is-symbol": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
@@ -3070,11 +3053,6 @@
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
-		"json5": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
-		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -3131,18 +3109,6 @@
 				"clone": "^2.1.1",
 				"loader-utils": "^1.1.0",
 				"pify": "^3.0.0"
-			},
-			"dependencies": {
-				"loader-utils": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-					"requires": {
-						"big.js": "^3.1.3",
-						"emojis-list": "^2.0.0",
-						"json5": "^0.5.0"
-					}
-				}
 			}
 		},
 		"loader-runner": {
@@ -3151,14 +3117,33 @@
 			"integrity": "sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw=="
 		},
 		"loader-utils": {
-			"version": "0.2.17",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-			"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+			"integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
 			"requires": {
-				"big.js": "^3.1.3",
-				"emojis-list": "^2.0.0",
-				"json5": "^0.5.0",
-				"object-assign": "^4.0.1"
+				"big.js": "^5.2.2",
+				"emojis-list": "^3.0.0",
+				"json5": "^1.0.1"
+			},
+			"dependencies": {
+				"big.js": {
+					"version": "5.2.2",
+					"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+					"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+				},
+				"emojis-list": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+					"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
+				},
+				"json5": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+					"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				}
 			}
 		},
 		"locate-path": {
@@ -3181,9 +3166,19 @@
 			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
 		},
 		"lower-case": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+			"requires": {
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+					"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+				}
+			}
 		},
 		"lru-cache": {
 			"version": "4.1.3",
@@ -3437,11 +3432,19 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
 		},
 		"no-case": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-			"integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
 			"requires": {
-				"lower-case": "^1.1.1"
+				"lower-case": "^2.0.2",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+					"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+				}
 			}
 		},
 		"node-libs-browser": {
@@ -6247,11 +6250,11 @@
 			}
 		},
 		"nth-check": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
-			"integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
 			"requires": {
-				"boolbase": "~1.0.0"
+				"boolbase": "^1.0.0"
 			}
 		},
 		"number-is-nan": {
@@ -6267,7 +6270,8 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"optional": true
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -6297,26 +6301,12 @@
 				}
 			}
 		},
-		"object-keys": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
-		},
 		"object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"requires": {
 				"isobject": "^3.0.0"
-			}
-		},
-		"object.getownpropertydescriptors": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.5.1"
 			}
 		},
 		"object.omit": {
@@ -6438,11 +6428,19 @@
 			}
 		},
 		"param-case": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
-			"integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+			"integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
 			"requires": {
-				"no-case": "^2.2.0"
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+					"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+				}
 			}
 		},
 		"parse-asn1": {
@@ -6480,6 +6478,22 @@
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
+				}
+			}
+		},
+		"pascal-case": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+			"requires": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+					"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
 				}
 			}
 		},
@@ -6554,12 +6568,19 @@
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
 		},
 		"pretty-error": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
-			"integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
+			"integrity": "sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==",
 			"requires": {
-				"renderkid": "^2.0.1",
-				"utila": "~0.4"
+				"lodash": "^4.17.20",
+				"renderkid": "^3.0.0"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.21",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+				}
 			}
 		},
 		"process": {
@@ -6741,7 +6762,7 @@
 		"relateurl": {
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
+			"integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
@@ -6749,21 +6770,34 @@
 			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
 		},
 		"renderkid": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
-			"integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
+			"integrity": "sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==",
 			"requires": {
-				"css-select": "^1.1.0",
-				"dom-converter": "~0.1",
-				"htmlparser2": "~3.3.0",
-				"strip-ansi": "^3.0.0",
-				"utila": "~0.3"
+				"css-select": "^4.1.3",
+				"dom-converter": "^0.2.0",
+				"htmlparser2": "^6.1.0",
+				"lodash": "^4.17.21",
+				"strip-ansi": "^6.0.1"
 			},
 			"dependencies": {
-				"utila": {
-					"version": "0.3.3",
-					"resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
-					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY="
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+				},
+				"lodash": {
+					"version": "4.17.21",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
 				}
 			}
 		},
@@ -7286,6 +7320,43 @@
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.0.tgz",
 			"integrity": "sha512-IlqtmLVaZA2qab8epUXbVWRn3aB1imbDMJtjB3nu4X0NqPkcY/JH9ZtCBWKHWPxs8Svi9tyo8w2dBoi07qZbBA=="
 		},
+		"terser": {
+			"version": "5.16.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
+			"integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
+			"requires": {
+				"@jridgewell/source-map": "^0.3.2",
+				"acorn": "^8.5.0",
+				"commander": "^2.20.0",
+				"source-map-support": "~0.5.20"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "8.8.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+					"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA=="
+				},
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"source-map-support": {
+					"version": "0.5.21",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+					"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
+					}
+				}
+			}
+		},
 		"through2": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
@@ -7345,11 +7416,6 @@
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
 			}
-		},
-		"toposort": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
-			"integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk="
 		},
 		"tough-cookie": {
 			"version": "2.4.3",
@@ -7439,22 +7505,6 @@
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
 					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
 				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"uglify-js": {
-			"version": "3.4.9",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
-			"requires": {
-				"commander": "~2.17.1",
-				"source-map": "~0.6.1"
-			},
-			"dependencies": {
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7573,11 +7623,6 @@
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
 			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw=="
 		},
-		"upper-case": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
-		},
 		"uri-js": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
@@ -7625,19 +7670,10 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
-		"util.promisify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-			"requires": {
-				"define-properties": "^1.1.2",
-				"object.getownpropertydescriptors": "^2.0.3"
-			}
-		},
 		"utila": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
-			"integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw="
+			"integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA=="
 		},
 		"uuid": {
 			"version": "3.3.2",
@@ -7723,18 +7759,6 @@
 				"uglifyjs-webpack-plugin": "^1.2.4",
 				"watchpack": "^1.5.0",
 				"webpack-sources": "^1.3.0"
-			},
-			"dependencies": {
-				"loader-utils": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-					"requires": {
-						"big.js": "^3.1.3",
-						"emojis-list": "^2.0.0",
-						"json5": "^0.5.0"
-					}
-				}
 			}
 		},
 		"webpack-cli": {
@@ -7752,18 +7776,6 @@
 				"supports-color": "^5.5.0",
 				"v8-compile-cache": "^2.0.2",
 				"yargs": "^12.0.2"
-			},
-			"dependencies": {
-				"loader-utils": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-					"requires": {
-						"big.js": "^3.1.3",
-						"emojis-list": "^2.0.0",
-						"json5": "^0.5.0"
-					}
-				}
 			}
 		},
 		"webpack-sources": {

--- a/demos/router-playground-lazy-load-angular6/package.json
+++ b/demos/router-playground-lazy-load-angular6/package.json
@@ -23,7 +23,7 @@
 		"@types/node": "^10.9.4",
 		"clean-webpack-plugin": "0.1.19",
 		"core-js": "2.5.7",
-		"html-webpack-plugin": "3.2.0",
+		"html-webpack-plugin": "5.5.0",
 		"less": "3.8.1",
 		"less-loader": "4.1.0",
 		"lodash": "4.17.11",


### PR DESCRIPTION
Bumps [json5](https://github.com/json5/json5) to 1.0.2 and updates ancestor dependencies [json5](https://github.com/json5/json5), [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) and [loader-utils](https://github.com/webpack/loader-utils). These dependencies need to be updated together.


Updates `json5` from 0.5.1 to 1.0.2
- [Release notes](https://github.com/json5/json5/releases)
- [Changelog](https://github.com/json5/json5/blob/main/CHANGELOG.md)
- [Commits](https://github.com/json5/json5/compare/v0.5.1...v1.0.2)

Updates `html-webpack-plugin` from 3.2.0 to 5.5.0
- [Release notes](https://github.com/jantimon/html-webpack-plugin/releases)
- [Changelog](https://github.com/jantimon/html-webpack-plugin/blob/main/CHANGELOG.md)
- [Commits](https://github.com/jantimon/html-webpack-plugin/compare/v3.2.0...v5.5.0)

Updates `loader-utils` from 1.1.0 to 1.4.2
- [Release notes](https://github.com/webpack/loader-utils/releases)
- [Changelog](https://github.com/webpack/loader-utils/blob/v1.4.2/CHANGELOG.md)
- [Commits](https://github.com/webpack/loader-utils/compare/v1.1.0...v1.4.2)

---
updated-dependencies:
- dependency-name: json5 dependency-type: indirect
- dependency-name: html-webpack-plugin dependency-type: direct:production
- dependency-name: loader-utils dependency-type: indirect ...